### PR TITLE
Fix 404 for cloudflare

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,5 +4,6 @@
   "compatibility_date": "2025-05-29",
   "assets": {
     "directory": "./dist",
+    "not_found_handling": "404-page",
   },
 }


### PR DESCRIPTION
previously you would get an empty 404 page from cloudflare like this:

<img width="1922" height="1003" alt="image" src="https://github.com/user-attachments/assets/3a460a49-aee4-4e2a-9d1b-692a7225ee25" />

Now you should get the proper 404 page